### PR TITLE
[FEAT] 책 이미지 위에 드롭다운 버튼 추가

### DIFF
--- a/src/assets/css/header.css
+++ b/src/assets/css/header.css
@@ -13,10 +13,8 @@
     align-items: center;
     justify-content: space-between;
     max-width: 1200px;
-    width: 100%;
     height: 130px;
     margin: 0 auto;
-    padding: 0 20px;
 }
 
 .overlap-group {
@@ -26,9 +24,47 @@
 }
 
 .logo {
+    position: relative;
     width: 152px;
     height: 65px;
     object-fit: cover;
+}
+
+.dropdown {
+    position: absolute;
+    top: 30px;
+    left: 130px;
+    z-index: 10;
+}
+
+.dropdown-toggle {
+    padding: 5px ;
+    background-color: #391902;
+    color: white;
+    border: none;
+    border-radius: 50%;
+    cursor: pointer;
+    font-size: 6px;
+}
+
+.dropdown-menu {
+    position: absolute;
+    left: 0;
+    background-color: white;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    z-index: 501;
+    width: 60px;
+    padding : 10px 12px;
+    box-shadow:0 2px 6px rgba(0, 0, 0, 0.1);
+}
+
+.dropdown-menu a {
+    display: block;
+    padding: 6px 10px;
+    text-decoration: none;
+    color: #333;
+    font-size: 14px;
 }
 
 .header-right {
@@ -42,6 +78,7 @@
     flex-direction: column;
     align-items: flex-end;
     gap: 10px;
+    top : 10px;
 }
 
 .header-icons {

--- a/src/components/layout/Header.vue
+++ b/src/components/layout/Header.vue
@@ -1,10 +1,16 @@
 <script setup>
-import { ref } from 'vue'
+import {onBeforeUnmount, onMounted, ref} from 'vue'
 import SearchBar from "@/components/common/SearchBar.vue";
 
 const isLoggedIn = ref(false);
 const memberStatus = ref('MEMBER');
 const cartCount = ref(0);
+const isOpen = ref(false)
+
+const toggleDropdown = () => {
+  isOpen.value = !isOpen.value
+}
+
 </script>
 
 <template>
@@ -12,18 +18,29 @@ const cartCount = ref(0);
     <div class="header">
       <div class="header-content">
         <div class="overlap-group">
-          <img class="logo" src="../../assets/images/logo.png" alt="로고" />
+          <RouterLink to="/">
+            <img class="logo" src="../../assets/images/logo.png" alt="로고" />
+          </RouterLink>
+          <div class="dropdown">
+            <!-- icon으로 바꾸는게 더 좋을듯!-->
+            <button v-if="!isOpen"  @click="toggleDropdown" class="dropdown-toggle">▶</button>
+            <button v-else @click="toggleDropdown" class="dropdown-toggle">▼</button>
+            <div v-if="isOpen" class="dropdown-menu">
+              <RouterLink to="/books">도서</RouterLink>
+              <RouterLink to="/posts">게시글</RouterLink>
+            </div>
+          </div>
         </div>
 
         <SearchBar/>
 
-        <div class="header-right">
+        <nav class="header-right">
           <div class="icon-group">
             <!-- 로그인 전 -->
             <template v-if="!isLoggedIn">
               <div class="auth-links">
-                <a href="/login" class="auth-link">로그인</a>
-                <a href="/signup" class="auth-link">회원가입</a>
+                <RouterLink to="/books" class="auth-link">로그인</RouterLink>
+                <RouterLink to="/signup" class="auth-link">회원가입</RouterLink>
               </div>
               <div class="header-icons">
                 <img class="icon" src="../../assets/icons/cart.png" alt="장바구니" />
@@ -34,7 +51,8 @@ const cartCount = ref(0);
             <!-- 관리자가 로그인 한 경우 -->
             <template v-else-if="memberStatus === 'ADMIN'">
               <div class="auth-links">
-                <a href="/admin" class="auth-link">관리자</a>
+                <RouterLink to="/admin" class="auth-link">관리자</RouterLink>
+                <!-- 로그아웃 된 다음에 메인 페이지로 이동할 예정 -->
                 <a href="/logout" class="auth-link logout">로그아웃</a>
               </div>
               <div class="header-icons">
@@ -46,6 +64,7 @@ const cartCount = ref(0);
             <!-- 회원이 로그인 한 경우 -->
             <template v-else-if="memberStatus === 'MEMBER'">
               <div class="auth-links">
+                <!-- 로그아웃 된 다음에 메인 페이지로 이동할 예정 -->
                 <a href="/logout" class="auth-link logout">로그아웃</a>
               </div>
               <div class="header-icons">
@@ -58,7 +77,8 @@ const cartCount = ref(0);
               </div>
             </template>
           </div>
-        </div>
+        </nav>
+
       </div>
     </div>
   </div>


### PR DESCRIPTION
- 다른 페이지로 이동되는 부분은 더 명확한 분류를 위해 div 대신 nav 라는 시멘틱 태그로 변경 
- 로그아웃 제외하고 a 태그 부분 RouterLink로 수정
- 헤더에서 로고 옆에 도서/게시글로 갈 수 있는 dropdown 버튼 생성