### PR TITLE
[REFACTOR] 장바구니 페이지에서 컴포넌트와 뷰를 명확하게 분리

### DIFF
--- a/src/features/cart/components/CartItem.vue
+++ b/src/features/cart/components/CartItem.vue
@@ -1,17 +1,21 @@
 <script setup>
-const {item} = defineProps(['item'])
-const emit = defineEmits(['increase', 'decrease', 'remove'])
+const {item} = defineProps(['item']);
+const emit = defineEmits(['increase', 'decrease', 'remove']);
 
 function increase() {
-    if (item.quantity < 999) emit('increase', item.id)
+    if (item.quantity < 999) {
+        emit('increase', item.id);
+    }
 }
 
 function decrease() {
-    if (item.quantity > 1) emit('decrease', item.id)
+    if (item.quantity > 1) {
+        emit('decrease', item.id);
+    }
 }
 
 function remove() {
-    emit('remove', item.id)
+    emit('remove', item.id);
 }
 
 function handleInput(item) {
@@ -26,17 +30,16 @@ function handleInput(item) {
 <template>
     <div id="cart-item-container"
          class="position-relative d-flex align-items-center justify-content-between border-bottom py-3">
+
         <!-- 체크박스 -->
         <input type="checkbox"
                v-model="item.selected"
                id="cart-checkbox"
                class="form-check-input position-absolute"/>
 
-        <!-- 왼쪽 영역 -->
+        <!-- 도서명, 가격 -->
         <div id="cart-left" class="d-flex align-items-center flex-grow-1">
-            <img :src="item.image"
-                 id="cart-image"
-                 alt="도서 이미지"/>
+            <img :src="item.image" id="cart-image" alt="도서 이미지"/>
             <div id="cart-book-info">
                 <div id="cart-book-title" class="fw-bold mb-2">{{ item.title }}</div>
                 <div>{{ item.price.toLocaleString() }}원</div>
@@ -46,7 +49,7 @@ function handleInput(item) {
         <!-- 중앙 회색 선 -->
         <div id="cart-divider"></div>
 
-        <!-- 오른쪽: 합계 가격 + 수량 -->
+        <!-- 수량 -->
         <div id="cart-right" class="d-flex flex-column align-items-center">
             <div id="cart-total-price" class="fw-bold mb-2 text-nowrap">
                 {{ (item.price * item.quantity).toLocaleString() }}원
@@ -67,10 +70,7 @@ function handleInput(item) {
         </div>
 
         <!-- 삭제 버튼 -->
-        <button @click="remove"
-                id="cart-remove-button"
-                class="btn btn-sm position-absolute">×
-        </button>
+        <button @click="remove" id="cart-remove-button" class="btn btn-sm position-absolute">×</button>
     </div>
 </template>
 
@@ -141,6 +141,7 @@ function handleInput(item) {
 #cart-quantity-input {
     width: 48px;
     font-size: 13px;
+    -moz-appearance: textfield;
 }
 
 /* 스핀 버튼 제거 */
@@ -148,10 +149,6 @@ function handleInput(item) {
 #cart-quantity-input::-webkit-inner-spin-button {
     -webkit-appearance: none;
     margin: 0;
-}
-
-#cart-quantity-input {
-    -moz-appearance: textfield;
 }
 
 #cart-remove-button {

--- a/src/features/cart/components/CartSummary.vue
+++ b/src/features/cart/components/CartSummary.vue
@@ -1,0 +1,62 @@
+<script setup>
+import { useRouter } from 'vue-router'
+import {useCartStore} from "@/features/cart/cart.js";
+
+const props = defineProps({
+    items: Array,
+    totalPrice: Number
+});
+
+const router = useRouter()
+const cartStore = useCartStore()
+
+const orderView = async () => {
+    const selectedItems = props.items.filter(i => i.selected)
+    const total = props.totalPrice
+
+    cartStore.setOrderData(selectedItems, total)
+    await router.push('/order')
+}
+</script>
+
+<template>
+    <div id="order-detail-info" class="border fw-bold rounded-4 border-black shadow-sm">
+        <div class="mb-3 d-flex justify-content-between">
+            <span>상품 금액</span>
+            <strong>{{ totalPrice.toLocaleString() }}원</strong>
+        </div>
+        <div class="mb-3 d-flex justify-content-between">
+            <span>배송비</span>
+            <span>0원</span>
+        </div>
+        <div class="mb-3 d-flex justify-content-between">
+            <span>상품 할인</span>
+            <span>0원</span>
+        </div>
+        <hr/>
+        <div class="mb-3 d-flex justify-content-between fw-bold">
+            <span>결제 예정 금액</span>
+            <span>{{ totalPrice.toLocaleString() }}원</span>
+        </div>
+        <div class="mb-3 d-flex justify-content-between">
+            <span>적립 예정 포인트</span>
+            <span>0P</span>
+        </div>
+        <button id="order-button" class="btn w-100 fw-bold" @click="orderView">주문하기</button>
+    </div>
+</template>
+
+<style scoped>
+#order-detail-info {
+    width: 274px;
+    height: 325px;
+    padding: 1.5rem;
+    margin-left: 2rem;
+}
+
+#order-button {
+    background-color: #f9f0df;
+    box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.25);
+    margin-top: 18px;
+}
+</style>

--- a/src/features/cart/views/CartView.vue
+++ b/src/features/cart/views/CartView.vue
@@ -1,6 +1,7 @@
 <script setup>
-import {reactive, computed} from 'vue'
-import CartItemView from "@/features/cart/views/CartItemView.vue";
+import {reactive, computed} from 'vue';
+import CartItem from "@/features/cart/components/CartItem.vue";
+import CartSummary from "@/features/cart/components/CartSummary.vue";
 
 const items = reactive([
     {id: 1, title: '도메인 주도 개발 시작하기', price: 25000, quantity: 1, selected: true, image: '/src/assets/images/ddd.png'},
@@ -42,74 +43,43 @@ function removeItem(id) {
 </script>
 
 <template>
-    <div id="cart-container" class="d-flex">
-        <div class="flex-grow-1">
-            <h3 class="fw-bold mb-4">장바구니</h3>
+    <div id="main-cart-container">
+        <div id="cart-container" class="d-flex">
+            <div class="flex-grow-1">
+                <h3 class="fw-bold mb-4">장바구니</h3>
 
-            <div id="select-all-box" class="form-check border-bottom py-3">
-                <input class="form-check-input" id="cart-all-checkbox" type="checkbox" v-model="allSelected"/>
-                <label class="form-check-label">전체 선택 {{ selectedCount }} / {{ items.length }}</label>
+                <div id="select-all-box" class="form-check border-bottom py-3">
+                    <input class="form-check-input" id="cart-all-checkbox" type="checkbox" v-model="allSelected"/>
+                    <label class="form-check-label">전체 선택 {{ selectedCount }} / {{ items.length }}</label>
+                </div>
+
+                <CartItem
+                        v-for="item in items"
+                        :key="item.id"
+                        :item="item"
+                        @increase="increaseQuantity"
+                        @decrease="decreaseQuantity"
+                        @remove="removeItem"
+                />
             </div>
 
-            <CartItemView
-                    v-for="item in items"
-                    :key="item.id"
-                    :item="item"
-                    @increase="increaseQuantity"
-                    @decrease="decreaseQuantity"
-                    @remove="removeItem"
-            />
-        </div>
-
-        <div id="order-detail-info" class="border fw-bold rounded-4 border-black shadow-sm">
-            <div class="mb-3 d-flex justify-content-between">
-                <span>상품 금액</span>
-                <strong>{{ totalPrice.toLocaleString() }}원</strong>
-            </div>
-            <div class="mb-3 d-flex justify-content-between">
-                <span>배송비</span>
-                <span>0원</span>
-            </div>
-            <div class="mb-3 d-flex justify-content-between">
-                <span>상품 할인</span>
-                <span>0원</span>
-            </div>
-            <hr/>
-            <div class="mb-3 d-flex justify-content-between fw-bold">
-                <span>결제 예정 금액</span>
-                <span>{{ totalPrice.toLocaleString() }}원</span>
-            </div>
-            <div class="mb-3 d-flex justify-content-between">
-                <span>적립 예정 포인트</span>
-                <span>0P</span>
-            </div>
-            <button id="order-button" class="btn w-100 fw-bold">주문하기</button>
+            <CartSummary :items="items" :totalPrice="totalPrice"/>
         </div>
     </div>
 </template>
 
 <style scoped>
+#main-cart-container {
+    max-width: 1200px;
+    margin: 3rem auto;
+}
+
 #cart-container {
-    margin-top: 3rem;
-    margin-bottom: 3rem;
     display: flex;
 }
 
 #select-all-box {
     margin-left: 9px;
-}
-
-#order-detail-info {
-    width: 274px;
-    height: 325px;
-    padding: 1.5rem;
-    margin-left: 2rem;
-}
-
-#order-button {
-    background-color: #f9f0df;
-    box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.25);
-    margin-top: 18px;
 }
 
 #cart-all-checkbox:checked {


### PR DESCRIPTION
## ✔️ 변경 사항
- 장바구니 페이지에서 필요한 도서 정보와 장바구니 요약 정보를`CartItem.vue`와 `CartSummary.vue`로 분리하고 컴포넌트 디렉토리에서 관리하도록 코드를 수정