### PR TITLE
[FIX] bootstrap의 css와의 중복을 피하기 클래스명 변경

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,13 +7,13 @@ import Header from "@/components/layout/Header.vue";
 </script>
 
 <template>
-  <div class="container">
     <Header/>
-      <RouterView/>
-<!--    <MyPageNav/>-->
-<!--    <AdminNav/>-->
+    <div class="container">
+          <RouterView/>
+    <!--    <MyPageNav/>-->
+    <!--    <AdminNav/>-->
+    </div>
     <Footer/>
-  </div>
 </template>
 
 <style scoped>

--- a/src/assets/css/footer.css
+++ b/src/assets/css/footer.css
@@ -1,6 +1,6 @@
 @charset "UTF-8";
 
-.footer {
+.book-footer {
     width: 100%;
     background-color: #f9f0df;
     border-top: 1px solid #d9d9d9;
@@ -9,28 +9,29 @@
     padding: 40px 0;
 }
 
-.footer-content {
+.book-footer-content {
     width: 1200px;
     position: relative;
 }
 
-.logo {
+.book-footer-logo {
     position: absolute;
     width: 254px;
     height: 90px;
     object-fit: cover;
 }
 
-.footer-links,
-.footer-info {
+.book-footer-links,
+.book-footer-info {
     display: flex;
     align-items: center;
     gap: 24px;
     margin-left: 300px;
     margin-bottom: 16px;
+    flex-wrap: wrap;
 }
 
-.text-wrapper {
+.book-footer-text {
     font-weight: 400;
     color: #391902;
     font-size: 16px;
@@ -41,7 +42,7 @@
     align-items: center;
 }
 
-.line {
+.book-footer-line {
     width: 1px;
     height: 16px;
     background-color: #391902;

--- a/src/components/layout/Footer.vue
+++ b/src/components/layout/Footer.vue
@@ -3,24 +3,24 @@
 </script>
 
 <template>
-  <div class="footer">
-    <div class="footer-content">
-      <img class="logo" src="../../assets/images/logo.png" alt="bookjeok-logo" />
-      <div class="footer-links">
-        <div class="text-wrapper">회사소개</div>
-        <div class="line"></div>
-        <div class="text-wrapper">이용약관</div>
-        <div class="line"></div>
-        <div class="text-wrapper">개인정보처리방침</div>
-      </div>
-      <div class="footer-info">
-        <div class="text-wrapper">대표이사 : 북적이</div>
-        <div class="text-wrapper">주소 : 서울시 동작구 보라매로 87 212</div>
-        <div class="text-wrapper">대표번호 : 1234-5678</div>
-        <div class="text-wrapper">사업자등록번호 : 123-45-67890</div>
-      </div>
+    <div class="book-footer">
+        <div class="book-footer-content">
+            <img class="book-footer-logo" src="../../assets/images/logo.png" alt="bookjeok-logo" />
+            <div class="book-footer-links">
+                <div class="book-footer-text">회사소개</div>
+                <div class="book-footer-line"></div>
+                <div class="book-footer-text">이용약관</div>
+                <div class="book-footer-line"></div>
+                <div class="book-footer-text">개인정보처리방침</div>
+            </div>
+            <div class="book-footer-info">
+                <div class="book-footer-text">대표이사 : 북적이</div>
+                <div class="book-footer-text">주소 : 서울시 동작구 보라매로 87 212</div>
+                <div class="book-footer-text">대표번호 : 1234-5678</div>
+                <div class="book-footer-text">사업자등록번호 : 123-45-67890</div>
+            </div>
+        </div>
     </div>
-  </div>
 </template>
 
 <style scoped>


### PR DESCRIPTION
footer css가 제대로 적용되지 않는 문제 발생
- bootstrap과의 css 중복을 피하기 위해 태그 안에 들어가는 클래스명 변경
- App.vue에서 header와 footer container 밖으로 빼기