### PR TITLE
[FIX] bootstrap의 css와 충돌 해결을 위해 클래스명 변경

### DIFF
--- a/src/assets/css/header.css
+++ b/src/assets/css/header.css
@@ -30,16 +30,16 @@
     object-fit: cover;
 }
 
-.dropdown {
+.header-dropdown {
     position: absolute;
     top: 30px;
     left: 130px;
     z-index: 10;
 }
 
-.dropdown-toggle {
+.header-dropdown-toggle {
     padding: 5px ;
-    background-color: #391902;
+    background-color: #854d14;
     color: white;
     border: none;
     border-radius: 50%;
@@ -47,19 +47,19 @@
     font-size: 6px;
 }
 
-.dropdown-menu {
+.header-dropdown-menu {
     position: absolute;
     left: 0;
     background-color: white;
     border: 1px solid #ddd;
     border-radius: 6px;
     z-index: 501;
-    width: 60px;
+    width: 90px;
     padding : 10px 12px;
     box-shadow:0 2px 6px rgba(0, 0, 0, 0.1);
 }
 
-.dropdown-menu a {
+.header-dropdown-menu a {
     display: block;
     padding: 6px 10px;
     text-decoration: none;

--- a/src/components/layout/Header.vue
+++ b/src/components/layout/Header.vue
@@ -21,11 +21,11 @@ const toggleDropdown = () => {
                     <RouterLink to="/">
                         <img class="logo" src="../../assets/images/logo.png" alt="로고"/>
                     </RouterLink>
-                    <div class="dropdown">
+                    <div class="header-dropdown">
                         <!-- icon으로 바꾸는게 더 좋을듯!-->
-                        <button v-if="!isOpen" @click="toggleDropdown" class="dropdown-toggle">▶</button>
-                        <button v-else @click="toggleDropdown" class="dropdown-toggle">▼</button>
-                        <div v-if="isOpen" class="dropdown-menu">
+                        <button v-if="!isOpen" @click="toggleDropdown" class="header-dropdown-toggle">▶</button>
+                        <button v-else @click="toggleDropdown" class="header-dropdown-toggle">▼</button>
+                        <div v-if="isOpen" class="header-dropdown-menu">
                             <RouterLink to="/books">도서</RouterLink>
                             <RouterLink to="/posts">게시글</RouterLink>
                         </div>


### PR DESCRIPTION
bootstrap의 css와 충돌 해결을 위해 클래스명 변경
- dropdown 이라는 이름이 포함된 클래스명 앞에 'header-' 삽입
- css에서 header-dropdown-menu 클래스의 너비를 90px으로 수정