### PR TITLE
[FEATURE] 주문 상세 내역 페이지 구현

### DIFF
--- a/src/features/order/components/OrderDetailCard.vue
+++ b/src/features/order/components/OrderDetailCard.vue
@@ -1,0 +1,88 @@
+<script setup>
+const props = defineProps({
+    order: {
+        type: Object,
+        required: true,
+    },
+});
+</script>
+
+<template>
+    <div class="mb-5">
+        <h4 class="fw-bold" id="order-info-title">주문 정보</h4>
+
+        <div v-for="item in order.items" :key="item.id" class="order-row">
+            <img :src="item.image" alt="도서 이미지" class="book-image"/>
+
+            <div class="info-row">
+                <div class="header-row">
+                    <div class="header">도서명</div>
+                    <div class="header">수량</div>
+                    <div class="header">금액</div>
+                </div>
+                <div class="content-row">
+                    <div class="title">{{ item.title }}</div>
+                    <div class="quantity">{{ item.quantity }}개</div>
+                    <div class="price">
+                        {{ (item.price * item.quantity).toLocaleString() }}원
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<style scoped>
+#order-info-title {
+    margin-top: 55px;
+    border-bottom: 2px solid black;
+    padding-bottom: 8px;
+}
+
+.order-row {
+    display: flex;
+    align-items: flex-start;
+    padding: 10px 0;
+    border-bottom: 1px solid #dee2e6;
+}
+
+.book-image {
+    width: 110px;
+    height: 136px;
+    object-fit: cover;
+    margin-right: 24px;
+}
+
+.info-row {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+.header-row {
+    display: flex;
+    justify-content: center;
+    margin-top: 25px;
+    margin-bottom: 4px;
+}
+
+.content-row {
+    display: flex;
+    margin-top: 10px;
+}
+
+.header {
+    font-size: 14px;
+    color: #999;
+    width: 33.3%;
+}
+
+.title,
+.quantity,
+.price {
+    font-size: 16px;
+    font-weight: bold;
+    width: 33.3%;
+}
+</style>

--- a/src/features/order/router.js
+++ b/src/features/order/router.js
@@ -13,5 +13,10 @@ export const orderRoutes = [
         path: '/members/orders',
         name: 'memberOrders',
         component: () => import('@/features/order/views/MemberOrdersView.vue')
+    },
+    {
+        path: '/members/orders/:orderId/order-detail',
+        name: 'orderDetail',
+        component: () => import('@/features/order/views/OrderDetailView.vue')
     }
 ]

--- a/src/features/order/views/OrderCompletionVIew.vue
+++ b/src/features/order/views/OrderCompletionVIew.vue
@@ -28,7 +28,7 @@ const items = [
 
 const totalPrice = items.reduce((sum, item) => sum + item.price * item.quantity, 0)
 
-const goToOrders = () => router.push('/orders')
+const goToOrders = () => router.push('/members/orders')
 const goToMain = () => router.push('/')
 </script>
 

--- a/src/features/order/views/OrderDetailView.vue
+++ b/src/features/order/views/OrderDetailView.vue
@@ -1,0 +1,82 @@
+<script setup>
+import MemberAddressInfo from "@/features/order/components/MemberAddressInfo.vue";
+import {onMounted, ref} from "vue";
+import {useRoute, useRouter} from "vue-router";
+import OrderDetailCard from "@/features/order/components/OrderDetailCard.vue";
+import PaymentInfo from "@/features/order/components/PaymentInfo.vue";
+
+const router = useRouter();
+const route = useRoute();
+const orders = ref([
+    {
+        id: 1,
+        date: "2025.04.18.",
+        orderId: "order-1746259565167",
+        items: [
+            {
+                id: 101,
+                image: "/src/assets/images/ddd.png",
+                title: "도메인 주도 개발 시작하기",
+                quantity: 1,
+                price: 25000,
+            },
+            {
+                id: 102,
+                image: "/src/assets/images/cleancode.png",
+                title: "Clean Code(클린 코드)",
+                quantity: 2,
+                price: 30000,
+            },
+        ],
+    },
+]);
+
+const totalPrice = orders.value.reduce(
+        (sum, order) => sum + order.items.reduce((sum, item) => sum + item.price * item.quantity, 0), 0);
+const filteredOrder = ref(null);
+
+onMounted(() => {
+    const orderId = route.params.orderId;
+    filteredOrder.value = orders.value.find((o) => o.orderId === orderId);
+});
+
+const goToOrders = () => router.push('/members/orders')
+</script>
+
+<template>
+    <div class="container">
+        <h3 class="fw-bold mb-4">주문 상세 내역</h3>
+        <MemberAddressInfo/>
+
+        <OrderDetailCard v-if="filteredOrder" :order="filteredOrder"/>
+        <div v-else>해당 주문을 찾을 수 없습니다.</div>
+
+        <PaymentInfo :totalPrice="totalPrice"/>
+
+        <div class="button-wrapper">
+            <button class="btn" id="order-button" @click="goToOrders">주문 내역 이동</button>
+        </div>
+
+    </div>
+</template>
+
+<style scoped>
+.container {
+    width: 900px;
+    margin-top: 42px;
+}
+
+.button-wrapper {
+    display: flex;
+    justify-content: center;
+    margin-top: 100px;
+    margin-bottom: 80px;
+}
+
+#order-button {
+    width: 200px;
+    font-weight: bold;
+    background-color: #E2D1C5;
+    box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.25);
+}
+</style>


### PR DESCRIPTION
## ✔️ 구현한 내용
- 라우터에 `/members/orders/:orderId/order-detail` path 등록
- 배송 정보를 제공하는 `MemberAddressInfo.vue` 컴포넌트를 `OrderDetailView.vue`에 추가
- 주문 정보를 제공하는 `OrderDetailCard.vue` 컴포넌트 구현
- 결제 정보를 제공하는 `PaymentInfo.vue` 컴포넌트를 `OrderDetailView.vue`에 추가

Close: #42 