### PR TITLE
[FEATRUE] 관리자 페이지 회원 목록 가져오는 페이지 및 공통 컴포넌트 생성

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,19 +1,29 @@
 <script setup>
 
-import Footer from "@/components/layout/Footer.vue"
-import MyPageNav from "@/components/common/MyPageNav.vue";
-import AdminNav from "@/components/layout/AdminNav.vue";
+import Footer from "@/components/layout/Footer.vue";
 import Header from "@/components/layout/Header.vue";
+import { useRoute } from "vue-router";
+import {computed} from "vue";
+
+const route = useRoute();
+// 관리자 경로인지 확인하는 부분
+const isAdminRoute = computed(() => {
+    const isAdmin = route.path.startsWith('/admin');
+    return isAdmin;
+});
 </script>
 
 <template>
-    <Header/>
-    <div class="container">
-          <RouterView/>
-    <!--    <MyPageNav/>-->
-    <!--    <AdminNav/>-->
+    <!-- 관리자가 아니면 헤더 표시 -->
+    <Header v-if="!isAdminRoute" />
+
+    <!-- 관리자가 아니면 container 클래스 적용 -->
+    <div :class="{ container: !isAdminRoute }">
+        <RouterView />
     </div>
-    <Footer/>
+
+    <!-- 관리자가 아니면 푸터 표시 -->
+    <Footer v-if="!isAdminRoute" />
 </template>
 
 <style scoped>

--- a/src/features/admin/components/AdminList.vue
+++ b/src/features/admin/components/AdminList.vue
@@ -1,0 +1,67 @@
+<script setup>
+defineProps({
+    headers: {
+        type: Array,
+        required: true
+    },
+    keyMap: {
+        type: Object,
+        required: true
+    },
+    rows: {
+        type: Array,
+        required: true
+    }
+});
+</script>
+
+<template>
+        <table class="admin-table">
+            <thead>
+                <tr class="table-header">
+                    <!-- headers의 배열을 반복해서 각 열의 헤더 생성하기 -->
+                    <th v-for="(header, index) in headers" :key="index">{{ header }}</th>
+                </tr>
+            </thead>
+
+            <tbody>
+                <!-- 데이터 행을 넣기! 실제 데이터 값이 이곳에 들어가는 것임 row 객체를 넣은 뒤 -->
+                <tr v-for="(row, rowIndex) in rows" :key="rowIndex" class="table-content">
+                    <!-- 여기에서 값을 빼서 넣으면서 정의하고 있음 row["memberId"] 이런식으로 결과가 도출 되는 것!-->
+                    <td
+                            v-for="(header, colIndex) in headers"
+                            :key="colIndex"
+                    >
+                        {{ row[keyMap[header]] }}
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+</template>
+
+
+<style scoped>
+.admin-table {
+    width: 900px;
+    /* 겹치는 테두리를 하나로 합치는 속성 */
+    border-collapse: collapse;
+    font-size: 16px;
+}
+
+.admin-table th,
+.admin-table td {
+    padding: 8px;
+    text-align: center;
+    background-color: #f9f0df;
+    color: #522404;
+}
+
+.admin-table tbody tr {
+    border-bottom: 1px solid #ddd;
+}
+
+.admin-table tbody tr td {
+    background-color: #fff;
+    color: #333;
+}
+</style>

--- a/src/features/admin/router.js
+++ b/src/features/admin/router.js
@@ -1,1 +1,10 @@
-export const adminRoutes = () => {};
+export const adminRoutes = [
+    {
+        path: '/admin',
+        name: 'AdminPage',
+        component: () => import('@/features/admin/views/AdminView.vue'),
+        children: [
+            { path: 'members', component: () => import('@/features/admin/views/AdminMemberView.vue')}
+        ]
+    },
+];

--- a/src/features/admin/views/AdminMemberView.vue
+++ b/src/features/admin/views/AdminMemberView.vue
@@ -1,0 +1,196 @@
+<script setup>
+import AdminList from "@/features/admin/components/AdminList.vue";
+import PagingBar from "@/components/common/PagingBar.vue";
+import AdminNav from "@/components/layout/AdminNav.vue";
+import SearchBar from "@/components/common/SearchBar.vue";
+import {onMounted, reactive, ref} from "vue";
+
+const members = ref([])
+
+const tableHeaders = [
+    "아이디", "이름", "이메일", "닉네임", "전화번호", "계정 생성 날짜", "마케팅 수신", "계정 상태"
+];
+
+const tableKeyMap = {
+    "아이디": "memberId",
+    "이름": "memberName",
+    "이메일": "email",
+    "닉네임": "nickname",
+    "전화번호": "phoneNumber",
+    "계정 생성 날짜": "createdAt",
+    "마케팅 수신": "marketingConsent",
+    "계정 상태": "activityStatus"
+};
+
+/*이 부분은 api로 가져오는 부분! */
+const tableRows = [
+    {
+        memberUid: 1,
+        memberId: "user01",
+        memberName: "김철수",
+        email: "chulsoo@example.com",
+        nickname: "철수",
+        phoneNumber: "010-1234-5678",
+        createdAt: "2024-05-01",
+        marketingConsent: "Y",
+        activityStatus: "activation"
+    },
+    {
+        memberUid: 2,
+        memberId: "user02",
+        memberName: "이영희",
+        email: "younghee@example.com",
+        nickname: "영희",
+        phoneNumber: "010-2345-6789",
+        createdAt: "2024-05-02",
+        marketingConsent: "N",
+        activityStatus: "activation"
+    },
+    {
+        memberUid: 3,
+        memberId: "user03",
+        memberName: "박민수",
+        email: "minsoo@example.com",
+        nickname: "민수",
+        phoneNumber: "010-3456-7890",
+        createdAt: "2024-05-03",
+        marketingConsent: "Y",
+        activityStatus: "activation"
+    },
+    {
+        memberUid: 4,
+        memberId: "user04",
+        memberName: "최지은",
+        email: "jieun@example.com",
+        nickname: "지은",
+        phoneNumber: "010-4567-8901",
+        createdAt: "2024-05-04",
+        marketingConsent: "Y",
+        activityStatus: "activation"
+    },
+    {
+        memberUid: 5,
+        memberId: "user05",
+        memberName: "정우성",
+        email: "woosung@example.com",
+        nickname: "우성",
+        phoneNumber: "010-5678-9012",
+        createdAt: "2024-05-05",
+        marketingConsent: "N",
+        activityStatus: "activation"
+    },
+    {
+        memberUid: 6,
+        memberId: "user06",
+        memberName: "한지민",
+        email: "jimin@example.com",
+        nickname: "지민",
+        phoneNumber: "010-6789-0123",
+        createdAt: "2024-05-06",
+        marketingConsent: "Y",
+        activityStatus: "activation"
+    },
+    {
+        memberUid: 7,
+        memberId: "user07",
+        memberName: "김범수",
+        email: "beomsu@example.com",
+        nickname: "범수",
+        phoneNumber: "010-7890-1234",
+        createdAt: "2024-05-07",
+        marketingConsent: "Y",
+        activityStatus: "activation"
+    },
+    {
+        memberUid: 8,
+        memberId: "user08",
+        memberName: "이하늬",
+        email: "hani@example.com",
+        nickname: "하늬",
+        phoneNumber: "010-8901-2345",
+        createdAt: "2024-05-08",
+        marketingConsent: "N",
+        activityStatus: "activation"
+    },
+    {
+        memberUid: 9,
+        memberId: "user09",
+        memberName: "서준호",
+        email: "junho@example.com",
+        nickname: "준호",
+        phoneNumber: "010-9012-3456",
+        createdAt: "2024-05-09",
+        marketingConsent: "Y",
+        activityStatus: "activation"
+    },
+    {
+        memberUid: 10,
+        memberId: "user10",
+        memberName: "홍길동",
+        email: "hong@example.com",
+        nickname: "길동",
+        phoneNumber: "010-0123-4567",
+        createdAt: "2024-05-10",
+        marketingConsent: "N",
+        activityStatus: "activation"
+    }, {
+        memberUid: 11,
+        memberId: "user10",
+        memberName: "홍길동",
+        email: "hong@example.com",
+        nickname: "길동",
+        phoneNumber: "010-0123-4567",
+        createdAt: "2024-05-10",
+        marketingConsent: "N",
+        activityStatus: "activation"
+    }
+];
+
+const itemsPerPage = 10;
+
+const pagination = reactive({
+    currentPage: 1,
+    totalPages: 1,
+    totalItems: 0
+})
+
+// 회원 목록 페이징 처리하기
+const fetchMembers= (page = 1) => {
+    const start = (page - 1) * itemsPerPage
+    const end = start + itemsPerPage
+
+    members.value = tableRows.slice(start, end)
+    pagination.currentPage = page
+    pagination.totalItems = tableRows.length
+    pagination.totalPages = Math.ceil(tableRows.length / itemsPerPage)
+
+    // 버튼 클릭시 최상단으로 올라갈 수 있게 조정
+    window.scrollTo(0,0)
+}
+
+onMounted(() => fetchMembers())
+</script>
+
+<template>
+    <div id="table-wrapper">
+        <!-- searchBar 내 버전으로 만들기-->
+        <SearchBar/>
+        <AdminList :headers="tableHeaders" :rows="members" :key-map="tableKeyMap"/>
+    </div>
+    <PagingBar
+            v-bind="pagination"
+            @page-changed="fetchMembers"
+    />
+</template>
+
+<style scoped>
+#table-wrapper {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    gap: 20px;
+    margin-top: 40px;
+}
+</style>

--- a/src/features/admin/views/AdminView.vue
+++ b/src/features/admin/views/AdminView.vue
@@ -1,0 +1,32 @@
+<script setup>
+
+import AdminNav from "@/components/layout/AdminNav.vue";
+</script>
+
+<template>
+    <div class="admin-container">
+        <div class="admin-layout-left">
+            <AdminNav/>
+        </div>
+        <div class="admin-layout-right">
+            <RouterView/>
+        </div>
+    </div>
+</template>
+
+<style scoped>
+.admin-container {
+    display: flex;
+    height: 100vh;
+}
+
+.admin-layout-left {
+    width: 280px;
+}
+
+.admin-layout-right {
+    width: calc(100% - 280px);
+    padding: 32px 16px;
+}
+
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,5 +1,5 @@
 import {createRouter, createWebHistory} from 'vue-router'
-// import {adminRoutes} from "@/features/admin/router.js";
+import {adminRoutes} from "@/features/admin/router.js";
 // import {bookRoutes} from "@/features/book/router.js";
 import {mainRoutes} from "@/features/main/router.js";
 import {memberRoutes} from "@/features/member/router.js";
@@ -11,7 +11,7 @@ const router = createRouter({
     /*import.meta.env.BASE_URL*/
     history: createWebHistory(),
     routes: [
-        // ...adminRoutes,
+        ...adminRoutes,
         // ...bookRoutes,
         ...mainRoutes,
         ...memberRoutes,


### PR DESCRIPTION
## ⭐구현 페이지 
관리자 페이지에서 회원 목록을 보여주는 페이지 구현 및 관리자 페이지에서 사용되는 공통 컴포넌트(표) 생성

## ✅ 상세 설명
- AdminList 컴포넌트 만들기 : 표가 있는 admin의 공통 컴포넌트
- AdminView 만들기 
- AdminMemberView 만들기 : 멤버 리스트를 가져오는 memberView 생성하기
- admin/router.js에 중첩 라우터 등록
- index.js에서 adminRoutes 등록
- App.vue에서 관리자인 경우에는 header와 footer가 적용되지 않고, container 클래스도 적용되지 않게 수정