### PR TITLE
[FEATURE] 장바구니 수량 입력 개선 및 주문 정보 연동 구현

### DIFF
--- a/src/features/cart/components/CartItem.vue
+++ b/src/features/cart/components/CartItem.vue
@@ -1,6 +1,13 @@
 <script setup>
 const {item} = defineProps(['item']);
-const emit = defineEmits(['increase', 'decrease', 'remove']);
+const emit = defineEmits(['increase', 'decrease', 'update', 'remove']);
+
+function confirmQuantityChange() {
+    if (!item.quantity || isNaN(item.quantity) || item.quantity < 1) {
+        item.quantity = 1;
+    }
+    emit('update', item);
+}
 
 function increase() {
     if (item.quantity < 999) {
@@ -18,11 +25,14 @@ function remove() {
     emit('remove', item.id);
 }
 
-function handleInput(item) {
-    if (item.quantity > 999) {
+function handleInput(e) {
+    const val = parseInt(e.target.value);
+    if (!val || isNaN(val) || val < 1) {
+        item.quantity = 0;
+    } else if (val > 999) {
         item.quantity = 999;
-    } else if (item.quantity < 1 || isNaN(item.quantity)) {
-        item.quantity = 1;
+    } else {
+        item.quantity = val;
     }
 }
 </script>
@@ -41,7 +51,7 @@ function handleInput(item) {
         <div id="cart-left" class="d-flex align-items-center flex-grow-1">
             <img :src="item.image" id="cart-image" alt="도서 이미지"/>
             <div id="cart-book-info">
-                <div id="cart-book-title" class="fw-bold mb-2">{{ item.title }}</div>
+                <div id="cart-book-title" class="fw-bold mb-2">{{ item.bookName }}</div>
                 <div>{{ item.price.toLocaleString() }}원</div>
             </div>
         </div>
@@ -60,9 +70,11 @@ function handleInput(item) {
                         type="number"
                         id="cart-quantity-input"
                         v-model.number="item.quantity"
-                        @input="handleInput(item)"
+                        @input="handleInput"
+                        @blur="confirmQuantityChange"
+                        @keyup.enter="confirmQuantityChange"
                         class="form-control text-center border-0"
-                        min="1"
+                        min="0"
                         max="999"
                 />
                 <button class="btn btn-sm btn-outline-secondary border-0" @click="increase">+</button>

--- a/src/features/cart/components/CartSummary.vue
+++ b/src/features/cart/components/CartSummary.vue
@@ -12,10 +12,19 @@ const cartStore = useCartStore()
 
 const orderView = async () => {
     const selectedItems = props.items.filter(i => i.selected)
-    const total = props.totalPrice
 
-    cartStore.setOrderData(selectedItems, total)
-    await router.push('/order')
+    let invalid = false;
+    selectedItems.forEach(item => {
+        if (!item.quantity || isNaN(item.quantity) || item.quantity < 1) {
+            item.quantity = 1; // 보정
+            invalid = true;
+        }
+    });
+
+    const total = props.totalPrice;
+
+    cartStore.setOrderData(selectedItems, total);
+    await router.push('/order');
 }
 </script>
 


### PR DESCRIPTION
## ✔️ 추가한 내용
- 수량 직접 입력 시 실시간으로 0 표시되며, 엔터 또는 포커스 아웃 시 자동으로 1로 보정
- 장바구니 수량 수정 API (PUT `/carts`) 및 삭제 API (DELETE `/carts`) 연동
- 장바구니 목록 조회 API (GET `/members/{id}/carts`) 연동
- 선택된 장바구니 도서 정보를 주문 페이지로 전달하여 주문 흐름 연계
- Pinia store를 활용한 주문 정보 상태 관리 적용