### PR TITLE
[FIX] 도서나 게시글 버튼 클릭 시 페이지 이동과 함께 메뉴가 닫히도록 수정

### DIFF
--- a/src/components/layout/Header.vue
+++ b/src/components/layout/Header.vue
@@ -26,8 +26,8 @@ const toggleDropdown = () => {
                         <button v-if="!isOpen" @click="toggleDropdown" class="header-dropdown-toggle">▶</button>
                         <button v-else @click="toggleDropdown" class="header-dropdown-toggle">▼</button>
                         <div v-if="isOpen" class="header-dropdown-menu">
-                            <RouterLink to="/books">도서</RouterLink>
-                            <RouterLink to="/posts">게시글</RouterLink>
+                            <RouterLink to="/books" @click="toggleDropdown">도서</RouterLink>
+                            <RouterLink to="/posts" @click="toggleDropdown">게시글</RouterLink>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## ✅ 상세 설명
- 도서나 게시글 버튼 클릭 시 페이지 이동과 함께 메뉴가 닫히도록 수정 (Close #64)
   - 클릭 시 `toggleDropdown` 작동하게 설정