### PR TITLE
[FEATURE] 주문 내역 페이지 API 응답 구조에 맞춰 Vue 컴포넌트 코드 수정

### DIFF
--- a/src/features/order/components/OrderCard.vue
+++ b/src/features/order/components/OrderCard.vue
@@ -1,7 +1,6 @@
-<!-- components/order/OrderCard.vue -->
 <script setup>
-import { defineProps, defineEmits } from 'vue'
-import { useRouter } from 'vue-router'
+import {defineProps} from 'vue'
+import {useRouter} from 'vue-router'
 
 const props = defineProps({
     order: {
@@ -11,21 +10,31 @@ const props = defineProps({
 })
 
 const router = useRouter()
-const emit = defineEmits(['detail'])
 
 const getOrderDetail = () => {
-    // 추후에 동적 ID 경로 적용 예정
-    router.push(`/members/orders/${props.order.orderId}/order-detail`)
+    router.push({
+        name: 'orderDetail',
+        params: {orderId: props.order.orderId}
+    })
+}
+
+const formatDate = (iso) => {
+    const date = new Date(iso)
+    return `${date.getFullYear()}.${(date.getMonth() + 1).toString().padStart(2, '0')}.${date.getDate().toString().padStart(2, '0')}.`
 }
 </script>
 
 <template>
     <div class="mb-5">
+        <!-- 주문 상단 헤더 -->
         <div class="order-header">
-            <span id="order-date-id">{{ order.date }} [{{ order.orderId }}]</span>
+      <span id="order-date-id">
+        {{ formatDate(order.orderedAt) }} [{{ order.orderId }}]
+      </span>
             <button class="btn" id="order-detail-btn" @click="getOrderDetail">주문 상세 내역</button>
         </div>
 
+        <!-- 주문 항목 목록 -->
         <div v-for="item in order.items" :key="item.id" class="order-row">
             <img :src="item.image" alt="도서 이미지" class="book-image"/>
 
@@ -39,7 +48,7 @@ const getOrderDetail = () => {
                     <div class="title">{{ item.title }}</div>
                     <div class="quantity">{{ item.quantity }}개</div>
                     <div class="price">
-                        {{ (item.price * item.quantity).toLocaleString() }}원
+                        {{ item.totalPrice.toLocaleString() }}원
                     </div>
                 </div>
             </div>
@@ -76,13 +85,6 @@ const getOrderDetail = () => {
     font-size: 14px;
     border-bottom: 2px solid black;
 }
-.order-item img {
-    width: 110px;
-    height: 136px;
-    object-fit: cover;
-    margin-right: 16px;
-    border-radius: 4px;
-}
 
 .order-row {
     display: flex;
@@ -96,6 +98,7 @@ const getOrderDetail = () => {
     height: 136px;
     object-fit: cover;
     margin-right: 24px;
+    border-radius: 4px;
 }
 
 .info-row {

--- a/src/features/order/views/MemberOrdersView.vue
+++ b/src/features/order/views/MemberOrdersView.vue
@@ -1,47 +1,51 @@
 <script setup>
-import MyPageNav from "@/components/common/MyPageNav.vue";
-import PagingBar from "@/components/common/PagingBar.vue";
-import OrderCard from "@/features/order/components/OrderCard.vue";
+import {ref, computed, onMounted, watch} from 'vue'
+import {useRoute} from 'vue-router'
+import axios from 'axios'
 
-import { ref, computed } from 'vue'
+import MyPageNav from "@/components/common/MyPageNav.vue"
+import PagingBar from "@/components/common/PagingBar.vue"
+import OrderCard from "@/features/order/components/OrderCard.vue"
+
+const route = useRoute()
+const memberId = route.params.memberId
 
 const currentPage = ref(1)
 const pageSize = 5
+const orders = ref([])
+const totalItems = ref(0)
 
-const orders = ref([
-    {
-        id: 1,
-        date: '2025.04.18.',
-        orderId: 'order-1746259565167',
-        items: [
-            {
-                id: 101,
-                image: '/src/assets/images/ddd.png',
-                title: '도메인 주도 개발 시작하기',
-                quantity: 1,
-                price: 25000
-            },
-            {
-                id: 102,
-                image: '/src/assets/images/cleancode.png',
-                title: 'Clean Code(클린 코드)',
-                quantity: 2,
-                price: 60000
-            }
-        ]
-    }
-])
-
-const totalItems = computed(() => orders.value.length)
 const totalPages = computed(() =>
-        Math.ceil(orders.value.length / pageSize)
+        Math.ceil(totalItems.value / pageSize)
 )
 
-const paginatedOrders = computed(() => {
-    const start = (currentPage.value - 1) * pageSize
-    const end = start + pageSize
-    return orders.value.slice(start, end)
-})
+const fetchOrders = async () => {
+    try {
+        const response = await axios.get(
+                `${import.meta.env.VITE_API_BASE_URL}/members/${memberId}/orders`,
+                {
+                    params: {
+                        page: currentPage.value - 1,
+                        size: pageSize,
+                        sort: 'orderedAt,desc'
+                    }
+                }
+        )
+
+        const rawItems = response.data.data.orders
+        totalItems.value = response.data.data.totalElements
+
+        orders.value = rawItems.map(order => ({
+            ...order,
+            totalAmount: order.items.reduce((sum, i) => sum + i.totalPrice, 0)
+        }))
+    } catch (e) {
+        console.error('주문 내역 조회 실패', e)
+    }
+}
+
+onMounted(fetchOrders)
+watch(currentPage, fetchOrders)
 
 const onPageChanged = (page) => {
     currentPage.value = page
@@ -51,15 +55,17 @@ const onPageChanged = (page) => {
 <template>
     <div class="mypage-container">
         <div class="mypage-layout-left">
-            <MyPageNav />
+            <MyPageNav/>
         </div>
         <div class="mypage-layout-right">
             <h3 class="fw-bold mb-4">주문 내역</h3>
 
-            <!-- 주문 카드 컴포넌트 사용 -->
-            <OrderCard v-for="order in paginatedOrders" :key="order.id" :order="order" />
+            <OrderCard
+                    v-for="order in orders"
+                    :key="order.orderId"
+                    :order="order"
+            />
 
-            <!-- 페이징 바 -->
             <PagingBar
                     :currentPage="currentPage"
                     :totalPages="totalPages"
@@ -84,14 +90,5 @@ const onPageChanged = (page) => {
 
 .mypage-layout-right {
     flex: 1;
-}
-
-.order-item img {
-    width: 110px;
-    height: 136px;
-    object-fit: cover;
-    margin-right: 16px;
-    border: 1px solid #dee2e6;
-    border-radius: 4px;
 }
 </style>


### PR DESCRIPTION
## ✔️ 변경 사항
- 기존 목업 데이터 기반 주문 내역 구현 → 백엔드 API 응답 기반으로 수정
- `orderId` 기준 그룹핑된 주문 응답 구조에 맞춰 `OrderCard.vue` 렌더링 방식 변경
- `orderedAt` ISO 날짜 포맷을 yyyy.MM.dd. 형식으로 변환하여 출력
- 총 주문 금액(totalAmount) 계산 로직 추가
- `router.push()` 방식 변경 (`orderDetail` 네이밍 라우터 사용)