### PR TITLE
[FEATURE] 주문 상세 페이지에서 백엔드 API를 통해 실제 주문 데이터 조회 기능 구현

### DIFF
--- a/src/features/order/components/MemberAddressInfo.vue
+++ b/src/features/order/components/MemberAddressInfo.vue
@@ -11,7 +11,7 @@ watchEffect(() => {
 
     isOrderCompletePage.value =
             path.includes('/order/completion') ||
-            /^\/members\/orders\/[a-z0-9]+\/order-detail$/.test(path);
+            /^\/members\/[^/]+\/orders\/[a-z0-9]+\/order-detail$/.test(path);
 });
 </script>
 

--- a/src/features/order/router.js
+++ b/src/features/order/router.js
@@ -15,7 +15,7 @@ export const orderRoutes = [
         component: () => import('@/features/order/views/MemberOrdersView.vue')
     },
     {
-        path: '/members/orders/:orderId/order-detail',
+        path: '/members/:memberId/orders/:orderId/order-detail',
         name: 'orderDetail',
         component: () => import('@/features/order/views/OrderDetailView.vue')
     }

--- a/src/features/order/views/MemberOrdersView.vue
+++ b/src/features/order/views/MemberOrdersView.vue
@@ -68,7 +68,7 @@ const onPageChanged = (page) => {
 
             <PagingBar
                     :currentPage="currentPage"
-                    :totalPages="totalPages"
+                    :totalPage="totalPages"
                     :totalItems="totalItems"
                     @page-changed="onPageChanged"
             />

--- a/src/features/order/views/OrderDetailView.vue
+++ b/src/features/order/views/OrderDetailView.vue
@@ -1,62 +1,83 @@
 <script setup>
-import MemberAddressInfo from "@/features/order/components/MemberAddressInfo.vue";
-import {onMounted, ref} from "vue";
-import {useRoute, useRouter} from "vue-router";
-import OrderDetailCard from "@/features/order/components/OrderDetailCard.vue";
-import PaymentInfo from "@/features/order/components/PaymentInfo.vue";
+import { ref, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import axios from 'axios'
 
-const router = useRouter();
-const route = useRoute();
-const orders = ref([
-    {
-        id: 1,
-        date: "2025.04.18.",
-        orderId: "order-1746259565167",
-        items: [
-            {
-                id: 101,
-                image: "/src/assets/images/ddd.png",
-                title: "도메인 주도 개발 시작하기",
-                quantity: 1,
-                price: 25000,
-            },
-            {
-                id: 102,
-                image: "/src/assets/images/cleancode.png",
-                title: "Clean Code(클린 코드)",
-                quantity: 2,
-                price: 30000,
-            },
-        ],
-    },
-]);
+import MemberAddressInfo from "@/features/order/components/MemberAddressInfo.vue"
+import OrderDetailCard from "@/features/order/components/OrderDetailCard.vue"
+import PaymentInfo from "@/features/order/components/PaymentInfo.vue"
 
-const totalPrice = orders.value.reduce(
-        (sum, order) => sum + order.items.reduce((sum, item) => sum + item.price * item.quantity, 0), 0);
-const filteredOrder = ref(null);
+const route = useRoute()
+const router = useRouter()
 
-onMounted(() => {
-    const orderId = route.params.orderId;
-    filteredOrder.value = orders.value.find((o) => o.orderId === orderId);
-});
+const memberId = route.params.memberId
+const orderId = route.params.orderId
 
-const goToOrders = () => router.push('/members/orders')
+const filteredOrder = ref(null)
+const totalPrice = ref(0)
+const paymentMethod = ref('')
+
+const formatDate = (iso) => {
+    const date = new Date(iso)
+    return `${date.getFullYear()}.${(date.getMonth() + 1).toString().padStart(2, '0')}.${date.getDate().toString().padStart(2, '0')}.`
+}
+
+const fetchOrderDetail = async () => {
+    try {
+        const res = await axios.get(`${import.meta.env.VITE_API_BASE_URL}/members/${memberId}/orders/${orderId}/order-detail`)
+        const data = res.data.data
+
+        if (!data) {
+            console.warn('주문 정보를 찾을 수 없습니다.')
+            return
+        }
+
+        filteredOrder.value = {
+            orderId: data.orderId,
+            orderedAt: data.orderedAt,
+            items: data.books.map((book, index) => ({
+                id: index,
+                image: book.imageUrl,
+                title: book.bookName,
+                quantity: book.quantity,
+                price: book.totalPrice / book.quantity
+            }))
+        }
+
+        totalPrice.value = data.paymentDetail.totalAmount
+        paymentMethod.value = data.paymentDetail.paymentMethod
+    } catch (err) {
+        console.error("주문 상세 조회 실패", err)
+    }
+}
+
+onMounted(fetchOrderDetail)
+
+const goToOrders = () => {
+    router.push(`/members/${memberId}/orders`)
+}
 </script>
 
 <template>
     <div class="container">
         <h3 class="fw-bold mb-4">주문 상세 내역</h3>
-        <MemberAddressInfo/>
 
-        <OrderDetailCard v-if="filteredOrder" :order="filteredOrder"/>
+        <div v-if="filteredOrder" class="order-meta-box">
+            <div class="meta-item">{{ formatDate(filteredOrder.orderedAt) }}</div>
+            <div class="meta-divider"></div>
+            <div class="meta-item fw-bold">주문 번호 : {{ filteredOrder.orderId }}</div>
+        </div>
+
+        <MemberAddressInfo />
+
+        <OrderDetailCard v-if="filteredOrder" :order="filteredOrder" />
         <div v-else>해당 주문을 찾을 수 없습니다.</div>
 
-        <PaymentInfo :totalPrice="totalPrice"/>
+        <PaymentInfo :totalPrice="totalPrice" :paymentMethod="paymentMethod" />
 
         <div class="button-wrapper">
             <button class="btn" id="order-button" @click="goToOrders">주문 내역 이동</button>
         </div>
-
     </div>
 </template>
 
@@ -78,5 +99,34 @@ const goToOrders = () => router.push('/members/orders')
     font-weight: bold;
     background-color: #E2D1C5;
     box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.25);
+}
+
+.order-meta-box {
+    width: 900px;
+    background-color: #E2D1C5;
+    border-radius: 10px;
+    padding: 10px 20px;
+    display: inline-flex;
+    align-items: center;
+    font-weight: bold;
+    font-size: 14px;
+    color: #000;
+    box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
+}
+
+.order-meta-box {
+    color: #444;
+}
+
+.meta-divider {
+    height: 16px;
+    width: 1px;
+    background-color: #6c757d;
+    margin: 0 16px;
+}
+
+.order-meta-box,
+.order-meta-box {
+    white-space: nowrap;
 }
 </style>


### PR DESCRIPTION
## ✔️ 변경 사항
- 기존 주문 상세 페이지(OrderDetailView.vue)에서 사용하던 더미 데이터 제거
- 백엔드 API(`/members/{memberId}/orders/{orderId}/order-detail`)를 호출하여 실제 주문 정보를 조회하도록 기능 수정
- API 응답 데이터를 기반으로 다음 정보 렌더링:
  - 주문 일자 및 주문 번호
  - 주문 도서 목록 (도서명, 수량, 금액)
  - 총 결제 금액 및 결제 수단 (PaymentInfo 컴포넌트에 전달)
- 주문 목록으로 돌아가기 기능에서 `memberId` 포함된 경로로 router.push 수정
- 스타일 개선: 주문 메타 정보 박스 추가 및 시각적 강조