### PR TITLE
[STYLE] 주문 정보 레이아웃 통일 및 수량과 금액 위치 조정

### DIFF
--- a/src/features/order/components/OrderCard.vue
+++ b/src/features/order/components/OrderCard.vue
@@ -118,12 +118,28 @@ const formatDate = (iso) => {
 .content-row {
     display: flex;
     margin-top: 10px;
+    align-items: center;
+}
+
+.header:nth-child(1),
+.title {
+    width: 50%;
+}
+
+.header:nth-child(2),
+.quantity {
+    width: 25%;
+}
+
+.header:nth-child(3),
+.price {
+    width: 25%;
+    padding-left: 60px;
 }
 
 .header {
     font-size: 14px;
     color: #999;
-    width: 33.3%;
 }
 
 .title,
@@ -131,6 +147,5 @@ const formatDate = (iso) => {
 .price {
     font-size: 16px;
     font-weight: bold;
-    width: 33.3%;
 }
 </style>

--- a/src/features/order/components/OrderDetailCard.vue
+++ b/src/features/order/components/OrderDetailCard.vue
@@ -70,12 +70,28 @@ const props = defineProps({
 .content-row {
     display: flex;
     margin-top: 10px;
+    align-items: center;
+}
+
+.header:nth-child(1),
+.title {
+    width: 50%;
+}
+
+.header:nth-child(2),
+.quantity {
+    width: 25%;
+}
+
+.header:nth-child(3),
+.price {
+    width: 25%;
+    padding-left: 60px;
 }
 
 .header {
     font-size: 14px;
     color: #999;
-    width: 33.3%;
 }
 
 .title,
@@ -83,6 +99,5 @@ const props = defineProps({
 .price {
     font-size: 16px;
     font-weight: bold;
-    width: 33.3%;
 }
 </style>

--- a/src/features/order/components/OrderItem.vue
+++ b/src/features/order/components/OrderItem.vue
@@ -61,12 +61,28 @@ const props = defineProps({
 .content-row {
     display: flex;
     margin-top: 10px;
+    align-items: center;
+}
+
+.header:nth-child(1),
+.title {
+    width: 50%;
+}
+
+.header:nth-child(2),
+.quantity {
+    width: 25%;
+}
+
+.header:nth-child(3),
+.price {
+    width: 25%;
+    padding-left: 60px;
 }
 
 .header {
     font-size: 14px;
     color: #999;
-    width: 33.3%;
 }
 
 .title,
@@ -74,6 +90,5 @@ const props = defineProps({
 .price {
     font-size: 16px;
     font-weight: bold;
-    width: 33.3%;
 }
 </style>


### PR DESCRIPTION
## ✔️ 변경 사항
- 주문 정보(도서명, 수량, 금액) 레이아웃 통일
- 수량과 금액 항목의 너비를 조정하고, 금액은 너무 오른쪽으로 붙지 않도록 자연스럽게 정렬