### PR TITLE
[STYLE] 페이징바 margin 크기 조절

### DIFF
--- a/src/components/common/PagingBar.vue
+++ b/src/components/common/PagingBar.vue
@@ -74,7 +74,8 @@ const visiblePages = computed(() => {
     justify-content: center;
     gap: 2px;
     flex-wrap: wrap;
-    margin-top: 20px;
+    margin-top: 40px;
+    margin-bottom: 40px;
 }
 
 .pagination-arrow,
@@ -99,11 +100,5 @@ const visiblePages = computed(() => {
     background-color: #f9f0df;
     color: white;
     font-weight: bold;
-}
-
-.pagination-info {
-    margin-left: 1rem;
-    font-size: 0.875rem;
-    color: #757575;
 }
 </style>


### PR DESCRIPTION
## ✔️ 변경 사항
- `.pagination` 클래스의 `margin-top`을 기존 20px에서 40px으로 확대
- `margin-bottom: 40px` 속성 추가로 하단 여백 확보