### PR TITLE
[FIX] 장바구니 이미지 경로 처리 로직 수정

### DIFF
--- a/src/features/cart/components/CartItem.vue
+++ b/src/features/cart/components/CartItem.vue
@@ -1,6 +1,10 @@
 <script setup>
+import {computed} from "vue";
+
 const {item} = defineProps(['item']);
 const emit = defineEmits(['increase', 'decrease', 'update', 'remove']);
+
+console.log(item);
 
 function confirmQuantityChange() {
     if (!item.quantity || isNaN(item.quantity) || item.quantity < 1) {
@@ -35,6 +39,16 @@ function handleInput(e) {
         item.quantity = val;
     }
 }
+
+const IMAGE_BASE_URL = 'http://localhost:8080/images/';
+
+const fullImageUrl = computed(() => {
+    return item.image.startsWith('http')
+            ? item.image
+            : IMAGE_BASE_URL + item.image
+})
+
+console.log(fullImageUrl);
 </script>
 
 <template>
@@ -49,7 +63,7 @@ function handleInput(e) {
 
         <!-- 도서명, 가격 -->
         <div id="cart-left" class="d-flex align-items-center flex-grow-1">
-            <img :src="item.image" id="cart-image" alt="도서 이미지"/>
+            <img :src="fullImageUrl" id="cart-image" alt="도서 이미지"/>
             <div id="cart-book-info">
                 <div id="cart-book-title" class="fw-bold mb-2">{{ item.bookName }}</div>
                 <div>{{ item.price.toLocaleString() }}원</div>
@@ -111,8 +125,8 @@ function handleInput(e) {
 }
 
 #cart-image {
-    width: 110px;
-    height: 136px;
+    width: auto;
+    height: 160px;
     object-fit: cover;
     margin-left: 20px;
     margin-right: 1rem;

--- a/src/features/order/components/OrderCard.vue
+++ b/src/features/order/components/OrderCard.vue
@@ -22,6 +22,8 @@ const formatDate = (iso) => {
     const date = new Date(iso)
     return `${date.getFullYear()}.${(date.getMonth() + 1).toString().padStart(2, '0')}.${date.getDate().toString().padStart(2, '0')}.`
 }
+
+const IMAGE_BASE_URL = 'http://localhost:8080/images/';
 </script>
 
 <template>
@@ -37,7 +39,7 @@ const formatDate = (iso) => {
 
         <!-- 주문 항목 목록 -->
         <div v-for="item in order.items" :key="item.id" class="order-row">
-            <img :src="item.image" alt="도서 이미지" class="book-image"/>
+            <img :src="item.imageUrl.startsWith('http') ? item.imageUrl : IMAGE_BASE_URL + item.imageUrl" alt="도서 이미지" class="book-image"/>
 
             <div class="info-row">
                 <div class="header-row">
@@ -102,8 +104,8 @@ const formatDate = (iso) => {
 }
 
 .book-image {
-    width: 110px;
-    height: 136px;
+    width: auto;
+    height: 160px;
     object-fit: cover;
     margin-right: 24px;
     border-radius: 4px;

--- a/src/features/order/components/OrderDetailCard.vue
+++ b/src/features/order/components/OrderDetailCard.vue
@@ -5,6 +5,8 @@ const props = defineProps({
         required: true,
     },
 });
+
+const IMAGE_BASE_URL = 'http://localhost:8080/images/'
 </script>
 
 <template>
@@ -12,7 +14,7 @@ const props = defineProps({
         <h4 class="fw-bold" id="order-info-title">주문 정보</h4>
 
         <div v-for="item in order.items" :key="item.id" class="order-row">
-            <img :src="item.image" alt="도서 이미지" class="book-image"/>
+            <img :src="item.image.startsWith('http') ? item.image : IMAGE_BASE_URL + item.image" alt="도서 이미지" class="book-image"/>
 
             <div class="info-row">
                 <div class="header-row">
@@ -47,8 +49,8 @@ const props = defineProps({
 }
 
 .book-image {
-    width: 110px;
-    height: 136px;
+    width: auto;
+    height: 160px;
     object-fit: cover;
     margin-right: 24px;
 }

--- a/src/features/order/components/OrderItem.vue
+++ b/src/features/order/components/OrderItem.vue
@@ -1,5 +1,5 @@
 <script setup>
-import {defineProps} from "vue";
+import {computed, defineProps} from "vue";
 
 const props = defineProps({
     item: {
@@ -7,11 +7,21 @@ const props = defineProps({
         required: true
     }
 });
+
+const IMAGE_BASE_URL = 'http://localhost:8080/images/';
+
+const fullImageUrl = computed(() => {
+    return props.item.image.startsWith('http')
+            ? props.item.image
+            : IMAGE_BASE_URL + props.item.image
+})
+
+console.log(fullImageUrl);
 </script>
 
 <template>
     <div class="order-row">
-        <img :src="item.image" alt="도서 이미지" class="book-image"/>
+        <img :src="fullImageUrl" alt="도서 이미지" class="book-image"/>
 
         <div class="info-row">
             <div class="header-row">
@@ -37,8 +47,8 @@ const props = defineProps({
 }
 
 .book-image {
-    width: 110px;
-    height: 136px;
+    width: auto;
+    height: 160px;
     object-fit: cover;
     margin-right: 24px;
     border-radius: 4px;


### PR DESCRIPTION
## ✔️ 변경 사항
- `item.image` 또는 `item.imageUrl` 값이 http로 시작하는지 여부를 기준으로 절대/상대 경로 처리