### PR TITLE
[FIX] 도서 상세 페이지 버그 수정

### DIFF
--- a/src/features/book/components/BookInfoHeader.vue
+++ b/src/features/book/components/BookInfoHeader.vue
@@ -52,7 +52,7 @@
 
                 <div class="actions">
                     <button class="gray" :class="{ active: isBookLiked }" @click="toggleBookLike">관심도서 ♥</button>
-                    <button class="gray" @click="addToCart" :class="{ active: isBookLiked }">장바구니</button>
+                    <button class="gray" @click="addToCart">장바구니</button>
                 </div>
 
                 <div class="order">

--- a/src/features/book/components/BookReviews.vue
+++ b/src/features/book/components/BookReviews.vue
@@ -76,7 +76,7 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue';
+import {ref, computed, onMounted} from 'vue';
 import { Doughnut } from 'vue-chartjs';
 import {
     Chart as ChartJS,
@@ -104,7 +104,6 @@ const props = defineProps({
 
 const reviewArray = computed(() => props.reviews?.reviews || []);
 
-const total = reviewArray.value.length;
 const showForm = ref(false);
 const newReview = ref('');
 const newRating = ref(0);
@@ -166,7 +165,7 @@ const getStarClass = (index, rating) => {
     return 'empty';
 };
 
-const emit = defineEmits(['submit-review']);
+const emit = defineEmits(['submit-reviews']);
 
 const updateRating = (cnt) => {
     rating.value = cnt;
@@ -176,7 +175,7 @@ const updateRating = (cnt) => {
 const submitReview = () => {
     if (!newReview.value || !rating.value) return;
 
-    emit('submit-review', {
+    emit('submit-reviews', {
         content : newReview.value,
         rating : newRating.value
     });

--- a/src/features/book/components/BookTabs.vue
+++ b/src/features/book/components/BookTabs.vue
@@ -15,7 +15,7 @@
                     :reviews="reviews"
                     :ratingCounts="ratingCounts"
                     :isPurchaser="isPurchaser"
-                    @submit-review="handleSubmitReviews"
+                    @submit-reviews="handleReviewSubmit"
             />
         </div>
 
@@ -37,7 +37,7 @@ const props = defineProps({
 });
 
 const reviewArray = computed(() => props.reviews?.reviews || []);
-const reviewCount = reviewArray.value.length;
+const reviewCount = computed(() => reviewArray.value.length);
 
 const ratingCounts = computed(() => {
     const ratingArr = [0, 0, 0, 0, 0];
@@ -69,7 +69,7 @@ const scrollTo = (tab) => {
 
 const emit = defineEmits(['submit-reviews']);
 
-const handleSubmitReviews = (payload) => {
+const handleReviewSubmit = (payload) => {
     emit('submit-reviews', payload);
 };
 </script>


### PR DESCRIPTION
## 🐞 발생 원인
- 장바구니 버튼에 active class 적용되어 관심 도서 toggleEvent 실행 시 같이 적용 받음
- 양방향 바인딩 이벤트 명이 상이하여 호출 안됨

## 🍀해결 방법
- 장바구니 버튼 active class 삭제
- 이벤트 명 통일