### PR TITLE
[FEAT] 헤더와, 주문 성공 페이지 경로 설정 올바르게 수정

### DIFF
--- a/src/components/layout/Header.vue
+++ b/src/components/layout/Header.vue
@@ -89,10 +89,12 @@ onMounted(() => {
                             </div>
                             <div class="header-icons">
                                 <img class="icon favorite" src="../../assets/icons/favorite.png" alt="관심 목록"/>
-                                <div class="cart-wrapper">
-                                    <img class="icon cart" src="../../assets/icons/cart.png" alt="장바구니"/>
-                                    <span v-if="cartCount > 0" class="cart-count">{{ cartCount }}</span>
-                                </div>
+                                <RouterLink to="/carts">
+                                    <div class="cart-wrapper">
+                                        <img class="icon" src="../../assets/icons/cart.png" alt="장바구니"/>
+                                        <span v-if="cartCount > 0" class="cart-count">{{ cartCount }}</span>
+                                    </div>
+                                </RouterLink>
                                 <img class="icon" src="../../assets/icons/mypage.png" alt="마이페이지"/>
                             </div>
                         </template>

--- a/src/features/order/views/OrderCompletionView.vue
+++ b/src/features/order/views/OrderCompletionView.vue
@@ -73,7 +73,8 @@ const fetchOrderCompletion = async () => {
 
 onMounted(fetchOrderCompletion)
 
-const goToOrders = () => router.push('/members/orders')
+const memberId = 'user01'
+const goToOrders = () => router.push(`/members/${memberId}/orders`)
 const goToMain = () => router.push('/')
 </script>
 


### PR DESCRIPTION
## ✔️ 추가한 내용
- 로그인 시 헤더 부분에서 장바구니 아이콘을 클릭하면 장바구니 페이지로 이동하도록 함
- 주문 완료 페이지에서 주문 내역 이동 버튼을 클릭 시 잘못된 경로로 이동하는 것을 수정 (`/members/${memberId}/orders`)